### PR TITLE
Misc. typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Mesh triangle reduction using quadrics - for Windows, OSX and Linux (thx Chris R
 
 ![img](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/blob/master/screenshot.png?raw=true)
 
-**Summary** Since I couldnt find any code thats fast, memory efficient, free and for high quality, I developed my version of the quadric based edge collapse mesh simplification method. It uses a threshold to determine which triangles to delete, which avoids sorting but might lead to lesser quality. It is about 4x as fast as Meshlab and can simplify 2M -> 30k triangles in 3.5 seconds.
+**Summary** Since I couldn't find any code that's fast, memory efficient, free and for high quality, I developed my version of the quadric based edge collapse mesh simplification method. It uses a threshold to determine which triangles to delete, which avoids sorting but might lead to lesser quality. It is about 4x as fast as Meshlab and can simplify 2M -> 30k triangles in 3.5 seconds.
 
 **Usage** The functionality is contained in Simplify.h. The function to call is *simplify_mesh(target_count)*. The code is kept pretty slim, so the main method has just around 400 lines of code. 
 
-**Obj File Limitations** The Obj file may only have one group or object. Its a very simple reader/writer, so dont try to use multiple objects in one file
+**Obj File Limitations** The Obj file may only have one group or object. Its a very simple reader/writer, so don't try to use multiple objects in one file
 
 **Windows, OSX and Linux Command Line Tool added**
 
@@ -21,7 +21,7 @@ https://github.com/neurolabusc/Fast-Quadric-Mesh-Simplification-Pascal-
 
 License : MIT
 
-Please dont forget to cite this page if you use the code!
+Please don't forget to cite this page if you use the code!
 
 ## Projects Using this Method
 

--- a/ext/GL/glut.h
+++ b/ext/GL/glut.h
@@ -242,7 +242,7 @@ extern void exit(int);
  glutJoystickFunc, glutForceJoystickFunc, glutStrokeWidthf,
  glutStrokeLengthf (NOT FINALIZED!).
 **/
-#ifndef GLUT_API_VERSION  /* allow this to be overriden */
+#ifndef GLUT_API_VERSION  /* allow this to be overridden */
 #define GLUT_API_VERSION                3
 #endif
 
@@ -286,7 +286,7 @@ extern void exit(int);
 
  GLUT_XLIB_IMPLEMENTATION=17 mjk's GLUT 3.8 with glutStrokeWidthf and glutStrokeLengthf
 **/
-#ifndef GLUT_XLIB_IMPLEMENTATION  /* Allow this to be overriden. */
+#ifndef GLUT_XLIB_IMPLEMENTATION  /* Allow this to be overridden. */
 #define GLUT_XLIB_IMPLEMENTATION        17
 #endif
 

--- a/ext/IL/config.h
+++ b/ext/IL/config.h
@@ -61,7 +61,7 @@
 
 //
 // sorry just
-// cant get this one to work under windows
+// can't get this one to work under windows
 // have disabled for the now
 //
 // will look at it some more later

--- a/ext/IL/config.h.in
+++ b/ext/IL/config.h.in
@@ -72,7 +72,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Use nonstandard varargs form for the GLU tesselator callback */
+/* Use nonstandard varargs form for the GLU tessellator callback */
 #undef HAVE_VARARGS_GLU_TESSCB
 
 /* Define to 1 if you have the <windows.h> header file. */

--- a/ext/IL/ilut_config.h
+++ b/ext/IL/ilut_config.h
@@ -7,7 +7,7 @@
 
 //
 // sorry just
-// cant get this one to work under windows
+// can't get this one to work under windows
 // have disabled for the now
 //
 // will look at it some more later

--- a/ext/glew/auto/bin/parse_spec.pl
+++ b/ext/glew/auto/bin/parse_spec.pl
@@ -107,7 +107,7 @@ my %taboo_tokens = (
 );
 
 # list of function definitions to be ignored, unless they are being defined in
-# the given spec.  This is an ugly hack arround the fact that people writing
+# the given spec.  This is an ugly hack around the fact that people writing
 # spec files seem to shut down all brain activity while they are at this task.
 #
 # This will be moved to its own file eventually.
@@ -169,7 +169,7 @@ sub normalize_prototype
     return $_;
 }
 
-# Ugly hack to work arround the fact that functions are declared in more
+# Ugly hack to work around the fact that functions are declared in more
 # than one spec file.
 sub ignore_function($$)
 {

--- a/ext/glew/auto/bin/update_registry.sh
+++ b/ext/glew/auto/bin/update_registry.sh
@@ -16,7 +16,7 @@ cd $1
 
 # wget used to return 0 (success), but more recent versions
 # don't so we don't want to bail out in failure mode
-# eventhough everything is fine.
+# even though everything is fine.
 
 set +e
 

--- a/ext/glew/auto/doc/advanced.html
+++ b/ext/glew/auto/doc/advanced.html
@@ -88,7 +88,7 @@ terminated with a semicolon.
 <h3>Custom Code Generation</h3>
 <p>
 Starting from GLEW 1.3.0, it is possible to control which extensions
-to include in the libarary by specifying a list in
+to include in the library by specifying a list in
 <tt>auto/custom.txt</tt>. This is useful when you do not need all the
 extensions and would like to reduce the size of the source files.
 Type <tt>make clean; make custom</tt> in the <tt>auto</tt> directory

--- a/ext/glew/auto/doc/credits.html
+++ b/ext/glew/auto/doc/credits.html
@@ -4,7 +4,7 @@
 GLEW was developed by <a href="http://www.cs.utah.edu/~ikits/">Milan
 Ikits</a> and <a
 href="http://wwwvis.informatik.uni-stuttgart.de/~magallon/">Marcelo
-Magallon</a>.  They also perform occasional maintainance to make sure
+Magallon</a>.  They also perform occasional maintenance to make sure
 that GLEW stays in mint condition.  Aaron Lefohn, Joe Kniss, and Chris
 Wyman were the first users and also assisted with the design and
 debugging process.  The acronym GLEW originates from Aaron Lefohn.

--- a/ext/glew/doc/advanced.html
+++ b/ext/glew/doc/advanced.html
@@ -187,7 +187,7 @@ terminated with a semicolon.
 <h3>Custom Code Generation</h3>
 <p>
 Starting from GLEW 1.3.0, it is possible to control which extensions
-to include in the libarary by specifying a list in
+to include in the library by specifying a list in
 <tt>auto/custom.txt</tt>. This is useful when you do not need all the
 extensions and would like to reduce the size of the source files.
 Type <tt>make clean; make custom</tt> in the <tt>auto</tt> directory

--- a/ext/glew/doc/credits.html
+++ b/ext/glew/doc/credits.html
@@ -103,7 +103,7 @@ width="88" height="32" border="0" alt="Support This Project"></a></td></tr> -->
 GLEW was developed by <a href="http://www.cs.utah.edu/~ikits/">Milan
 Ikits</a> and <a
 href="http://wwwvis.informatik.uni-stuttgart.de/~magallon/">Marcelo
-Magallon</a>.  They also perform occasional maintainance to make sure
+Magallon</a>.  They also perform occasional maintenance to make sure
 that GLEW stays in mint condition.  Aaron Lefohn, Joe Kniss, and Chris
 Wyman were the first users and also assisted with the design and
 debugging process.  The acronym GLEW originates from Aaron Lefohn.

--- a/ext/mathlib/transform44.h
+++ b/ext/mathlib/transform44.h
@@ -43,7 +43,7 @@ public:
     /// get optional scale pivot
     const vector3& getscalepivot() const;
     /// set matrix 4x4
-    void setmatrix(matrix44 matrix); //not per reference - so make shure the data is copyed
+    void setmatrix(matrix44 matrix); //not per reference - so make sure the data is copied
     /// get resulting 4x4 matrix
     const matrix44& getmatrix();
     /// return true if euler rotation is used (otherwise quaternion rotation is used)

--- a/src.cmd/Simplify.h
+++ b/src.cmd/Simplify.h
@@ -337,7 +337,7 @@ namespace Simplify
 	// Main simplification function
 	//
 	// target_count  : target nr. of triangles
-	// agressiveness : sharpness to increase the threashold.
+	// agressiveness : sharpness to increase the threshold.
 	//                 5..8 are good numbers
 	//                 more iterations yield higher quality
 	//
@@ -403,7 +403,7 @@ namespace Simplify
 					calculate_error(i0,i1,p);
 					deleted0.resize(v0.tcount); // normals temporarily
 					deleted1.resize(v1.tcount); // normals temporarily
-					// dont remove if flipped
+					// don't remove if flipped
 					if( flipped(p,i0,i1,v0,v1,deleted0) ) continue;
 
 					if( flipped(p,i1,i0,v1,v0,deleted1) ) continue;
@@ -495,7 +495,7 @@ namespace Simplify
 					deleted0.resize(v0.tcount); // normals temporarily
 					deleted1.resize(v1.tcount); // normals temporarily
 
-					// dont remove if flipped
+					// don't remove if flipped
 					if( flipped(p,i0,i1,v0,v1,deleted0) ) continue;
 					if( flipped(p,i1,i0,v1,v0,deleted1) ) continue;
 

--- a/src.gl/OBJ.h
+++ b/src.gl/OBJ.h
@@ -367,7 +367,7 @@ public:
 		for ( uint i = 0 ; i<materials.size(); i++ )
 			if ( name.compare( materials[i].name ) == 0 ) return i;
 
-		printf("couldnt find material %s\n",name.c_str() );
+		printf("couldn't find material %s\n",name.c_str() );
 		return -1;
 	}
 	void print_materials ()

--- a/src.gl/Simplify.h
+++ b/src.gl/Simplify.h
@@ -82,7 +82,7 @@ namespace Simplify
 	// Main simplification function 
 	//
 	// target_count  : target nr. of triangles
-	// agressiveness : sharpness to increase the threashold.
+	// agressiveness : sharpness to increase the threshold.
 	//                 5..8 are good numbers
 	//                 more iterations yield higher quality
 	//
@@ -146,7 +146,7 @@ namespace Simplify
 					deleted0.resize(v0.tcount); // normals temporarily
 					deleted1.resize(v1.tcount); // normals temporarily
 
-					// dont remove if flipped
+					// don't remove if flipped
 					if( flipped(p,i0,i1,v0,v1,deleted0) ) continue;
 					if( flipped(p,i1,i0,v1,v0,deleted1) ) continue;
 


### PR DESCRIPTION
Found via `codespell -q 3 -L uint,lod,iff,pevent`
(BTW, is `ext/` considered 3rdparty libs ?)