### PR TITLE
Fix for issue 24 

### DIFF
--- a/src.cmd/Simplify.h
+++ b/src.cmd/Simplify.h
@@ -635,7 +635,9 @@ namespace Simplify
 		if( iteration == 0 )
 		{
 			loopi(0,vertices.size())
-			vertices[i].q=SymetricMatrix(0.0);
+				vertices[i].q=SymetricMatrix(0.0);
+			loopi(0,vertices.size())
+				vertices[i].border=0;
 
 			loopi(0,triangles.size())
 			{

--- a/src.cmd/Simplify.h
+++ b/src.cmd/Simplify.h
@@ -626,38 +626,6 @@ namespace Simplify
 			triangles.resize(dst);
 		}
 		//
-		// Init Quadrics by Plane & Edge Errors
-		//
-		// required at the beginning ( iteration == 0 )
-		// recomputing during the simplification is not required,
-		// but mostly improves the result for closed meshes
-		//
-		if( iteration == 0 )
-		{
-			loopi(0,vertices.size())
-				vertices[i].q=SymetricMatrix(0.0);
-			loopi(0,vertices.size())
-				vertices[i].border=0;
-
-			loopi(0,triangles.size())
-			{
-				Triangle &t=triangles[i];
-				vec3f n,p[3];
-				loopj(0,3) p[j]=vertices[t.v[j]].p;
-				n.cross(p[1]-p[0],p[2]-p[0]);
-				n.normalize();
-				t.n=n;
-				loopj(0,3) vertices[t.v[j]].q =
-					vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
-			}
-			loopi(0,triangles.size())
-			{
-				// Calc Edge Error
-				Triangle &t=triangles[i];vec3f p;
-				loopj(0,3) t.err[j]=calculate_error(t.v[j],t.v[(j+1)%3],p);
-				t.err[3]=min(t.err[0],min(t.err[1],t.err[2]));
-			}
-		}
 
 		// Init Reference ID list
 		loopi(0,vertices.size())
@@ -693,9 +661,16 @@ namespace Simplify
 			}
 		}
 
-		// Identify boundary : vertices[].border=0,1
+		// Init Quadrics by Plane & Edge Errors
+		//
+		// required at the beginning ( iteration == 0 )
+		// recomputing during the simplification is not required,
+		// but mostly improves the result for closed meshes
+		//
 		if( iteration == 0 )
 		{
+			// Identify boundary : vertices[].border=0,1
+
 			std::vector<int> vcount,vids;
 
 			loopi(0,vertices.size())
@@ -729,6 +704,28 @@ namespace Simplify
 				}
 				loopj(0,vcount.size()) if(vcount[j]==1)
 					vertices[vids[j]].border=1;
+			}
+			//initialize errors
+			loopi(0,vertices.size())
+				vertices[i].q=SymetricMatrix(0.0);
+
+			loopi(0,triangles.size())
+			{
+				Triangle &t=triangles[i];
+				vec3f n,p[3];
+				loopj(0,3) p[j]=vertices[t.v[j]].p;
+				n.cross(p[1]-p[0],p[2]-p[0]);
+				n.normalize();
+				t.n=n;
+				loopj(0,3) vertices[t.v[j]].q =
+					vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
+			}
+			loopi(0,triangles.size())
+			{
+				// Calc Edge Error
+				Triangle &t=triangles[i];vec3f p;
+				loopj(0,3) t.err[j]=calculate_error(t.v[j],t.v[(j+1)%3],p);
+				t.err[3]=min(t.err[0],min(t.err[1],t.err[2]));
 			}
 		}
 	}

--- a/src.gl/Simplify.h
+++ b/src.gl/Simplify.h
@@ -250,7 +250,7 @@ namespace Simplify
 	// compact triangles, compute edge error and build reference list
 
 	void update_mesh(int iteration)
-	{		
+	{
 		if(iteration>0) // compact triangles
 		{
 			int dst=0;
@@ -262,40 +262,8 @@ namespace Simplify
 			triangles.resize(dst);
 		}
 		//
-		// Init Quadrics by Plane & Edge Errors
-		//
-		// required at the beginning ( iteration == 0 )
-		// recomputing during the simplification is not required,
-		// but mostly improves the result for closed meshes
-		//
-		if( iteration == 0 )
-		{
-			loopi(0,vertices.size())
-				vertices[i].q=SymetricMatrix(0.0);
-			loopi(0,vertices.size())
-				vertices[i].border=0;
 
-			loopi(0,triangles.size()) 
-			{
-				Triangle &t=triangles[i]; 
-				vec3f n,p[3];
-				loopj(0,3) p[j]=vertices[t.v[j]].p;
-				n.cross(p[1]-p[0],p[2]-p[0]);
-				n.normalize();
-				t.n=n;
-				loopj(0,3) vertices[t.v[j]].q = 
-					vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
-			}
-			loopi(0,triangles.size())
-			{
-				// Calc Edge Error
-				Triangle &t=triangles[i];vec3f p;
-				loopj(0,3) t.err[j]=calculate_error(t.v[j],t.v[(j+1)%3],p);
-				t.err[3]=min(t.err[0],min(t.err[1],t.err[2]));
-			}	
-		}
-
-		// Init Reference ID list	
+		// Init Reference ID list
 		loopi(0,vertices.size())
 		{
 			vertices[i].tstart=0;
@@ -319,7 +287,7 @@ namespace Simplify
 		refs.resize(triangles.size()*3);
 		loopi(0,triangles.size())
 		{
-			Triangle &t=triangles[i];	
+			Triangle &t=triangles[i];
 			loopj(0,3)
 			{
 				Vertex &v=vertices[t.v[j]];
@@ -329,9 +297,16 @@ namespace Simplify
 			}
 		}
 
-		// Identify boundary : vertices[].border=0,1 
+		// Init Quadrics by Plane & Edge Errors
+		//
+		// required at the beginning ( iteration == 0 )
+		// recomputing during the simplification is not required,
+		// but mostly improves the result for closed meshes
+		//
 		if( iteration == 0 )
 		{
+			// Identify boundary : vertices[].border=0,1
+
 			std::vector<int> vcount,vids;
 
 			loopi(0,vertices.size())
@@ -345,7 +320,7 @@ namespace Simplify
 				loopj(0,v.tcount)
 				{
 					int k=refs[v.tstart+j].tid;
-					Triangle &t=triangles[k];	
+					Triangle &t=triangles[k];
 					loopk(0,3)
 					{
 						int ofs=0,id=t.v[k];
@@ -355,7 +330,7 @@ namespace Simplify
 							ofs++;
 						}
 						if(ofs==vcount.size())
-						{ 
+						{
 							vcount.push_back(1);
 							vids.push_back(id);
 						}
@@ -364,7 +339,29 @@ namespace Simplify
 					}
 				}
 				loopj(0,vcount.size()) if(vcount[j]==1)
-					vertices[vids[j]].border=1;					
+					vertices[vids[j]].border=1;
+			}
+			//initialize errors
+			loopi(0,vertices.size())
+				vertices[i].q=SymetricMatrix(0.0);
+
+			loopi(0,triangles.size())
+			{
+				Triangle &t=triangles[i];
+				vec3f n,p[3];
+				loopj(0,3) p[j]=vertices[t.v[j]].p;
+				n.cross(p[1]-p[0],p[2]-p[0]);
+				n.normalize();
+				t.n=n;
+				loopj(0,3) vertices[t.v[j]].q =
+					vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
+			}
+			loopi(0,triangles.size())
+			{
+				// Calc Edge Error
+				Triangle &t=triangles[i];vec3f p;
+				loopj(0,3) t.err[j]=calculate_error(t.v[j],t.v[(j+1)%3],p);
+				t.err[3]=min(t.err[0],min(t.err[1],t.err[2]));
 			}
 		}
 	}

--- a/src.gl/Simplify.h
+++ b/src.gl/Simplify.h
@@ -270,8 +270,10 @@ namespace Simplify
 		//
 		if( iteration == 0 )
 		{
-			loopi(0,vertices.size()) 
-			vertices[i].q=SymetricMatrix(0.0);
+			loopi(0,vertices.size())
+				vertices[i].q=SymetricMatrix(0.0);
+			loopi(0,vertices.size())
+				vertices[i].border=0;
 
 			loopi(0,triangles.size()) 
 			{


### PR DESCRIPTION
This pull request fixes [issue 24](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/issues/24). 

The first iteration of the function update_mesh() calls [calculate_error()](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/blob/eca167ac1c51b21e01af5a15f1c2e979b334fffe/src.cmd/Simplify.h#L655) before the `border` state has been assigned. Therefore, the behavior of [`det != 0 && !border`](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/blob/eca167ac1c51b21e01af5a15f1c2e979b334fffe/src.cmd/Simplify.h#L785) is not predictable.

The updated code simply changes the order of operations: identifying borders prior to calculating the initial edge error terms.