### PR TITLE
Mention C port

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ Tiger Yuhao Huang](https://myminifactory.github.io/Fast-Quadric-Mesh-Simplificat
 
 **[ Java Mesh Decimator by Jayfella](https://hub.jmonkeyengine.org/t/isosurface-mesh-simplifier/41046)**
 
+**[ Port from C++ to pure C by Chris Rorden](https://github.com/neurolabusc/nii2mesh). Includes routines for Marching Cubes and Laplacian HC mesh smoothing.**


### PR DESCRIPTION
I have ported this terrific simplification algorithm from C++ code to C. The [nii2mesh](https://github.com/neurolabusc/nii2mesh) project shows how this can be applied to convert voxelwise medical images to meshes (supporting NIfTI format, with dcm2niix converting DICOM to NIfTI). The repository also includes the minimal `obj2mesh` that demonstrates the mesh simplification alone.

The rationale for this port is that it will dramatically accelerate AFNI [SurfMesh](https://afni.nimh.nih.gov/pub/dist/doc/program_help/SurfMesh.html). It will also add new functionality to [niimath](https://github.com/rordenlab/niimath) and [the WASM-extension for NiiVue](https://github.com/niivue/niivue).

The original C++ code showcases elegant operator overloading that is not available in pure C. Therefore, the pure C code is not pretty. However, it does have the following attributes:

 - While numerically identical, the C code is ~20% faster than the C++ code. The C++ code frequently resizes arrays, while the C code over-provisions these arrays at initialization. The input mesh is freed during the simplification, so peak memory is actually a bit less than the C++.
 - The pure C code integrates the lossy and lossless functions into a single function. There are three modes of operation: 
   1. Lossless only (mimics C++ `simplify_mesh_lossless()`).
   2. Lossy only (mimics C++ `simplify_mesh()`).
   3. Lossy than lossless finishing (similar but faster than running C++ `simplify_mesh()` and `simplify_mesh_lossless()` sequentially).
 - I have included a function `laplacian_smoothHC()` which implements [Laplacian Smoothing with Humphrey’s Classes](https://onlinelibrary.wiley.com/doi/10.1111/1467-8659.00334). For sample noisy meshes where this helps, see [here](https://github.com/alecjacobson/geometry-processing-smoothing). I initially wrote this in [C++](https://github.com/neurolabusc/nii2meshCPP/blob/f9c762a95b5bee479cd83c36bb3d9f34b0494c91/src/Simplify.h#L492) if there is any interest in inserting this in the original C++ project. It leverages the efficient vertex border detection from @sp4cerat's original code.
 - The C code does not handle texture UV's. This was not required for my application. Since the C port closely follows the C++ code, it would be easy to add if required.
 - Unlike the C++ code, the pure C code can be run in parallel with OpenMP. Each mesh is simplified serially, but multiple meshes can be compressed by the same program in parallel. To demonstrate this, the pure C project can be compiled with `OMP=1 make -j` and then run in atlas mode, e.g. `nii2mesh -a 1 D99_atlas_v2.0_right.nii.gz D99.gii`. In practice, this algorithm is so fast that saving files to disk quickly becomes the bottleneck.



